### PR TITLE
Add dependent: :destroy to the document associations

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -1,5 +1,5 @@
 Spree::Order.class_eval do
-  has_many :bookkeeping_documents, as: :printable
+  has_many :bookkeeping_documents, as: :printable, dependent: :destroy
   has_one :invoice, -> { where(template: 'invoice') },
           class_name: 'Spree::BookkeepingDocument',
           as: :printable

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -89,5 +89,17 @@ RSpec.describe Spree::Order do
         end
       end
     end
+
+    describe 'destruction' do
+      let!(:order) { create :invoiceable_order }
+
+      context "when destroyed" do
+        it 'also destroys the invoice' do
+          expect(Spree::BookkeepingDocument.count).not_to eq(0)
+          order.destroy!
+          expect(Spree::BookkeepingDocument.count).to eq(0)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
When you delete a `Spree::Order`, you'll end up with invalid documents (the
document won't be able to infer its view class or fetch any of its contents).

That happened here, and it'd be much nicer if the document just went away when the
order in question is destroyed, too.

Of course: Do not destroy completed orders if you don't exactly know what you're doing!