### PR TITLE
Never generate more than one invoice

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -37,7 +37,12 @@ Spree::Order.class_eval do
   end
 
   def invoice_for_order
-    bookkeeping_documents.create(template: 'invoice')
-    bookkeeping_documents.create(template: 'packaging_slip')
+    # Under some conditions this method could be called more than once.
+    # We have to make sure that an invoice/packaging slip is never created more
+    # than once for an order.
+    ActiveRecord::Base.transaction do
+      create_invoice unless invoice.present?
+      create_packaging_slip unless packaging_slip.present?
+    end
   end
 end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -36,6 +36,13 @@ RSpec.describe Spree::Order do
         order.next
       end.to change { Spree::BookkeepingDocument.count }
     end
+
+    it 'prevents #invoice_for_order from creating too many documents' do
+      order.next
+      expect do
+        order.invoice_for_order
+      end.to_not change { Spree::BookkeepingDocument.count }
+    end
   end
 
   describe 'deprecated methods' do


### PR DESCRIPTION
Previously when a an order, for whatever reason, transitioned more than
once to the `completed` state, the gem would generate invoices and
packaging slips again with new identifiers.